### PR TITLE
ensure transmitted "event" type messages only trigger correct callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -371,7 +371,9 @@ class Entangld {
             let count = 0;
             for (let s of this._subscriptions) {
 
-                if (this._is_beneath(path, s.path)) {
+                // Check the message's uuid against the subscriptions to make sure
+                //  only the correct callback is evaluated
+                if (msg.uuid === s.uuid) {
 
                     // Call the callback
                     s.callback(path, msg.value);
@@ -393,7 +395,7 @@ class Entangld {
 
             // Create a new subscription that simply transmits when triggered
             this._subscribe(msg.path.path, (path, val) => {
-                const response = new Entangld_Message("event", path, val);
+                const response = new Entangld_Message("event", path, val, msg.path.uuid); // include uuid to ensure only the correct subscription gets the callback evaluated downstream
                 this._transmit(response, obj);
             }, obj, msg.path.uuid);
 

--- a/test/events.js
+++ b/test/events.js
@@ -164,4 +164,29 @@ describe("Events",()=>{
 
 		c.set("rubbish.bin","boot");
 	});
+
+
+	it("Upstream event only triggers a single downstream callback when multiple subscriptions co-exist", (done)=>{
+
+		// Subscribe once to a remote endpoint
+		var sub_1_triggers = 0;
+		s.subscribe("a.some_data",(path, val)=>{
+			sub_1_triggers += 1;
+			assert.strictEqual(sub_1_triggers, 1);
+		});
+
+		// Subscribe again to the same remote endpoint
+		var sub_2_triggers = 0;
+		s.subscribe("a.some_data",(path, val)=>{
+			sub_2_triggers += 1;
+			assert.strictEqual(sub_2_triggers, 1);
+		});
+
+		a.set("some_data",0);
+
+		// Let everything clear
+		setTimeout(() => {
+			done();
+		}, 5)
+	});
 });

--- a/test/events.js
+++ b/test/events.js
@@ -1,6 +1,7 @@
 const Entangld=require("../index.js");
 const assert=require("assert");
 
+
 describe("Events",()=>{
 
 	var s=new Entangld();
@@ -166,7 +167,7 @@ describe("Events",()=>{
 	});
 
 
-	it("Upstream event only triggers a single downstream callback when multiple subscriptions co-exist", (done)=>{
+	it("Remote event only triggers a single subscribed callback when multiple subscriptions co-exist", (done)=>{
 
 		// Subscribe once to a remote endpoint
 		var sub_1_triggers = 0;
@@ -184,9 +185,27 @@ describe("Events",()=>{
 
 		a.set("some_data",0);
 
-		// Let everything clear
-		setTimeout(() => {
-			done();
-		}, 5)
+		done();
+	});
+
+	it("Local sets only triggers a single subscribed callback when multiple subscriptions co-exist", (done)=>{
+
+		// Subscribe once to a local endpoint
+		var sub_1_triggers = 0;
+		s.subscribe("some_data",(path, val)=>{
+			sub_1_triggers += 1;
+			assert.strictEqual(sub_1_triggers, 1);
+		});
+
+		// Subscribe again to the same local endpoint
+		var sub_2_triggers = 0;
+		s.subscribe("some_data",(path, val)=>{
+			sub_2_triggers += 1;
+			assert.strictEqual(sub_2_triggers, 1);
+		});
+
+		s.set("some_data",0);
+
+		done();
 	});
 });


### PR DESCRIPTION
This addresses the bug in Issue #6. It takes the approach of ensuring both callbacks only get called once. Additionally, it adds a test to `test/events.js` to check this functionality over remote datastores.